### PR TITLE
If date_dirs was not created at the end of lpdaac_getmod_dirs(), crea…

### DIFF
--- a/R/MODIStsp_lpdaac_accessoires.R
+++ b/R/MODIStsp_lpdaac_accessoires.R
@@ -150,6 +150,9 @@ if (class(items) == "try-error" & check_used_server) {
   }
 }
 
+# If the server is definitively down, create an empty date_dir in order not to get error
+if (!exists("date_dirs")) {date_dirs <- character(0); attr(date_dirs, "server") <- "http"}
+
 return(date_dirs)
 
 }


### PR DESCRIPTION
…te it empty in order not to get error